### PR TITLE
Control input sequences and amounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ Usage: psbt_faker [OPTIONS] OUTPUT.PSBT [XPUB]
 
 Options:
   -i, --num-ins INTEGER           Number of inputs (default 1)
+  -S, --sequence PARSE_INT_STRING
+                                  Sequence number for each input
   -o, --num-outs INTEGER          Number of all txn outputs (default 2)
+  -O, --output-amount INTEGER     Amount of each non-change output in sats
+                                  (default: all outputs are the same)
   -c, --num-change INTEGER        Number of change outputs (default 1) from
                                   num-outs
   -f, --fee INTEGER               Miner's fee in Satoshis

--- a/psbt_faker/__init__.py
+++ b/psbt_faker/__init__.py
@@ -19,12 +19,20 @@ b2a_hex = lambda a: str(_b2a_hex(a), 'ascii')
 
 SIM_XPUB = 'tpubD6NzVbkrYhZ4XzL5Dhayo67Gorv1YMS7j8pRUvVMd5odC2LBPLAygka9p7748JtSq82FNGPppFEz5xxZUdasBRCqJqXvUHq6xpnsMcYJzeh'
 
+def parse_int_string(v):
+    return int(v, 0)
+
+def repeat_until_length(values, target_length):
+    # Creates a list of target_length length, by repeating the values.
+    return [values[i % len(values)] for i in range(target_length)]
 
 @click.command()
 @click.argument('out_psbt', type=click.File('wb'), metavar="OUTPUT.PSBT")
 @click.argument('xpub', type=str, default=SIM_XPUB)
 @click.option('--num-ins', '-i', help="Number of inputs (default 1)", default=1)
+@click.option('--sequence', '-S', help="Sequence number for each input", multiple=True, type=parse_int_string)
 @click.option('--num-outs', '-o', help="Number of all txn outputs (default 2)", default=2)
+@click.option('--output-amount', '-O', help="Amount of each non-change output in sats (default: all outputs are the same)", multiple=True, default=(), type=int)
 @click.option('--num-change', '-c', help="Number of change outputs (default 1) from num-outs", default=1)
 @click.option('--fee', '-f', help="Miner's fee in Satoshis", default=1000)
 @click.option('--psbt2', '-2', help="Make PSBTv2", is_flag=True, default=False)
@@ -37,9 +45,9 @@ SIM_XPUB = 'tpubD6NzVbkrYhZ4XzL5Dhayo67Gorv1YMS7j8pRUvVMd5odC2LBPLAygka9p7748JtS
 @click.option('--zero-xfp', '-z', help="[SS] Provide zero XFP and junk XPUB (cannot be signed, but should be decodable)", is_flag=True, default=False)
 @click.option('--multisig', '-m', type=click.File('rt'), metavar="config.txt", help="[MS] CC Multisig config file (text)", default=None)
 @click.option('--locktime', '-l', help="nLocktime value (default 0), use 'current' to fetch best block height from mempool.space", default="0")
-@click.option('--input-amount', '-n', help="Size of each input in sats (default 100k sats each input)", default=100000)
+@click.option('--input-amount', '-n', help="Size of each input in sats (default 100k sats each input)", default=(100000,), multiple=True, type=int)
 @click.option('--incl-xpubs', '-I',  help="[MS] Include XPUBs in PSBT global section", is_flag=True, default=False)
-def main(num_ins, num_change, num_outs, out_psbt, testnet, xpub, segwit, fee, styles, base64,
+def main(num_ins, sequence, num_change, num_outs, output_amount, out_psbt, testnet, xpub, segwit, fee, styles, base64,
          partial, zero_xfp, multisig, locktime, input_amount, psbt2, incl_xpubs, wrapped):
     '''Construct a valid PSBT which spends non-existant BTC to random addresses!'''
 
@@ -53,27 +61,48 @@ def main(num_ins, num_change, num_outs, out_psbt, testnet, xpub, segwit, fee, st
     else:
         locktime = int(locktime)
 
+    input_amount = repeat_until_length(input_amount, num_ins)
+    change_outputs=list(range(num_change)) # always the first outputs
+
+    outvals = None
+    if output_amount: # not empty
+        output_amount = repeat_until_length(output_amount, num_outs - num_change)
+        if num_change > 0:
+            change_amount = int(round((sum(input_amount) - fee - sum(output_amount)) / num_change))
+            if change_amount <= 0:
+                raise ValueError("Change amount is too large")
+            outvals = [change_amount] * num_change + output_amount
+        else:
+            outvals = output_amount
+        # Update to final fee, after rounding and change amount calculation.
+        fee = sum(input_amount) - sum(outvals)
+
+    if len(sequence) > 0:
+        sequence = repeat_until_length(sequence, num_ins)
+    else:
+        sequence = None
+
     if multisig:
         ms_config = multisig.read()
         name, af, keys, M, N = from_simple_text(ms_config.split("\n"))
-        psbt, outs = fake_ms_txn(num_ins, num_outs, M, keys, fee=fee, locktime=locktime,
-                                 change_outputs=list(range(num_change)), outstyles=styles,
-                                 input_amount=input_amount, psbt_v2=psbt2, change_af=af,
-                                 incl_xpubs=incl_xpubs, is_testnet=testnet)
+        psbt, outs = fake_ms_txn(input_amount, num_outs, M, keys, fee=fee, outvals=outvals, locktime=locktime,
+                                 change_outputs=change_outputs, outstyles=styles,
+                                 psbt_v2=psbt2, change_af=af,
+                                 incl_xpubs=incl_xpubs, sequences=sequence, is_testnet=testnet)
     else:
         if zero_xfp:
             xpub = None
 
-        psbt, outs = fake_txn(num_ins, num_outs, master_xpub=xpub, fee=fee,
+        psbt, outs = fake_txn(input_amount, num_outs, master_xpub=xpub, outvals=outvals, fee=fee,
                               segwit_in=segwit, outstyles=styles, locktime=locktime,
                               partial=partial, is_testnet=testnet, wrapped=wrapped,
-                              change_outputs=list(range(num_change)),
-                              psbt_v2=psbt2, input_amount=input_amount)
+                              change_outputs=change_outputs,
+                              psbt_v2=psbt2, sequences=sequence)
 
 
     out_psbt.write(psbt if not base64 else b64encode(psbt))
 
-    print(f"\nFake PSBT would send {((num_ins*input_amount)/Decimal(1E8))} BTC to: ")
+    print(f"\nFake PSBT would send {(sum(input_amount)/Decimal(1E8))} BTC to: ")
     print('\n'.join(" %.8f => %s %s" % (Decimal(amt)/Decimal(1E8),dest, ' (change back)' if chg else '')
                                                                 for amt,dest,chg in outs))
     if fee:

--- a/psbt_faker/txn.py
+++ b/psbt_faker/txn.py
@@ -79,10 +79,12 @@ def make_change_addr(master_xfp, orig_der,  account_key, idx, style):
     return redeem_scr, actual_scr, is_segwit, dest.sec(), path
 
 
-def fake_txn(num_ins, num_outs, master_xpub=None, fee=10000,
+def fake_txn(input_amounts, num_outs, master_xpub=None, fee=10000,
          outvals=None, segwit_in=False, wrapped=False, outstyles=None,
-         change_outputs=[], op_return=None, psbt_v2=None, input_amount=1E8,
+         change_outputs=[], op_return=None, psbt_v2=None,
          locktime=0, sequences=None, is_testnet=False, partial=False):
+
+    num_ins = len(input_amounts)
 
     af = ("p2sh-p2wpkh" if wrapped else "p2wpkh") if segwit_in else "p2pkh"
 
@@ -185,7 +187,7 @@ def fake_txn(num_ins, num_outs, master_xpub=None, fee=10000,
             # p2pkh
             scr = bytes([0x76, 0xa9, 0x14]) + subkey.hash160() + bytes([0x88, 0xac])
 
-        supply.vout.append(CTxOut(int(input_amount), scr))
+        supply.vout.append(CTxOut(int(input_amounts[i]), scr))
 
         if segwit_in:
             # just utxo for segwit
@@ -259,10 +261,10 @@ def fake_txn(num_ins, num_outs, master_xpub=None, fee=10000,
         if psbt_v2:
             psbt.outputs[i].script = act_scr
             psbt.outputs[i].amount = int(
-                outvals[i] if outvals else round(((input_amount * num_ins) - fee) / num_outs, 4))
+                outvals[i] if outvals else round((sum(input_amounts) - fee) / num_outs, 4))
 
         if not outvals:
-            h = CTxOut(int(round(((input_amount * num_ins) - fee) / num_outs, 4)), act_scr)
+            h = CTxOut(int(round((sum(input_amounts) - fee) / num_outs, 4)), act_scr)
         else:
             h = CTxOut(int(outvals[i]), act_scr)
 
@@ -354,10 +356,12 @@ def make_ms_address(M, keys, idx, is_change, addr_fmt="p2wsh", testnet=1, bip67=
     return addr, scriptPubKey, script, bip32paths
 
 
-def fake_ms_txn(num_ins, num_outs, M, keys, fee=10000, outvals=None,
+def fake_ms_txn(input_amounts, num_outs, M, keys, fee=10000, outvals=None,
                 outstyles=['p2wsh'], change_outputs=[], incl_xpubs=False,
-                input_amount=1E8, bip67=True, locktime=0, psbt_v2=False,
+                bip67=True, locktime=0, psbt_v2=False,
                 sequences=None, is_testnet=False, change_af=None):
+    num_ins = len(input_amounts)
+
     # make various size MULTISIG txn's ... completely fake and pointless values
     # - but has UTXO's to match needs
     # spending change outputs
@@ -410,7 +414,7 @@ def fake_ms_txn(num_ins, num_outs, M, keys, fee=10000, outvals=None,
         )
         supply.vin = [CTxIn(out_point, nSequence=0xffffffff)]
 
-        supply.vout.append(CTxOut(int(input_amount), scriptPubKey))
+        supply.vout.append(CTxOut(int(input_amounts[i]), scriptPubKey))
 
         if "wsh" in change_af:
             psbt.inputs[i].utxo = supply.serialize_with_witness()
@@ -483,11 +487,11 @@ def fake_ms_txn(num_ins, num_outs, M, keys, fee=10000, outvals=None,
             if outvals:
                 psbt.outputs[i].amount = outvals[i]
             else:
-                psbt.outputs[i].amount = int(round(((input_amount * num_ins) - fee) / num_outs, 4))
+                psbt.outputs[i].amount = int(round((sum(input_amounts) - fee) / num_outs, 4))
 
 
         if not outvals:
-            h = CTxOut(int(round(((input_amount*num_ins)-fee) / num_outs, 4)), scriptPubKey)
+            h = CTxOut(int(round((sum(input_amounts)-fee) / num_outs, 4)), scriptPubKey)
         else:
             h = CTxOut(int(outvals[i]), scriptPubKey)
 


### PR DESCRIPTION
Accept one or more sequence values, and one or more input-amount values.
Using repeat_until_length we can make the values the same for all inputs (by giving only values), or different values -
if the length of values is smaller than the number of inputs, values will repeat from start.

Similarly control each output amount, and let it be different from change outputs.